### PR TITLE
Reorganized INSTALL.md and add missing information

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ Alternatively, you can download the source code directly from the repository loc
 git clone https://github.com/LibreHealthIO/LibreEHR librehealthehr
 ```
 
-###  Setup
+###  Setting Up
 
 To run LibreHealthEHR, MariaDB (prefered) or MySQL, and Apache or another PHP-capable webserver must be configured.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,33 +1,94 @@
 # Installation Instructions
-Last Updated: March 28, 2017
+Last Updated: December 26th, 2017
 
 ### Table of Contents
 
-**[Overview of Directories](#overview-of-directories)**
+**[1. Overview of Directories](#1.-overview-of-directories)**
 
-**[Unpacking](#unpacking)**
+**[2A. Windows Installation](#windows-setup)**
 
-**[Setup](#setup)**
+**[2B. Linux Installation](#linix-setup)**
 
-**[Setting up Access Control](#setting-up-access-control)**
+**[3. Setup](#setup)**
 
-**[Upgrading](#upgrading)**
+**[4. Setting up Access Control](#setting-up-access-control)**
 
-**[Windows Setup](#windows-setup)**
+**[5. Upgrading](#upgrading)**
 
-**[FAQ](#faq)**
+**[6. FAQ](#faq)**
 
-##  Overview of Directories
+##  1. Overview of Directories
 
-NOTE: Most recent documentation can be found on the online documentation at [LibreHealth](http://librehealth.io/).
+NOTE: The most recent documentations can be found on the [LibreHealth](http://librehealth.io/) website.
 
 contrib: Contains many user-contributed encounter forms and utilities
+
 custom: Contains scripts and other text files commonly customized
+
 Documentation: Contains useful documentation
+
 interface: Contains User Interface scripts and configuration
+
 library: Contains scripts commonly included in other scripts
+
 sql: Contains initial database images
+
 gacl: Contains embedded php-GACL (access controls)
+
+## 2A. Windows Installation
+
+To run LibreEHR on Windows, [XAMPP](https://www.apachefriends.org/index.html) or [WAMP](http://www.wampserver.com/en/) is needed with a compatible version of php. 
+
+**Note:** 
+
+1. Must have php [7.0](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/_) or [5.6](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/) ([5.6.30](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/5.6.30/) recommended)
+
+2. php 7.1x is not currently supported
+
+Navigate to your `php.ini` file. You can find the `php.ini` file by looking at the following destination :
+* In case of WAMP :
+`C:\WAMP\BIN\PHP\php.ini` OR (left click )  wampmanager icon -> PHP -> php.ini
+* In case of XAMPP:
+`C:\xampp\php\php.ini.`.
+
+Open this file with your text editor (eg. [Subl](https://www.sublimetext.com/3)).
+
+There will be 4 php files located in `xampp\php` or `\WAMP\BIN\PHP`. The one you need is the one with the file type "Configuration Settings". Make the following changes in the php.ini file:
+
+```
+max_execution_time = 600
+max_input_time = 600
+max_input_vars = 3000
+memory_limit = 512M
+post_max_size = 32M
+upload_max_filesize = 32M
+session.gc_maxlifetime = 14400
+short_open_tag = On
+display_errors = Off
+upload_tmp_dir is set to a correct default value that will work on your system
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE
+```
+
+**Make sure that strict mode is disabled in Mysql**
+
+**[How to disable Mysql strict mode?](#how-to-disable-mysql-strict-mode-?)**
+
+Clone the LibreEHR [repository](https://github.com/LibreHealthIO/LibreEHR) into your computer using a console  (eg. [GitBash](https://git-for-windows.github.io/) or [Cmder](http://cmder.net/)).
+
+The cloned repository should be moved into the root folder of the webserver you are using. For WAMP, you should put the 'LibreEHR' folder into `\wamp\www\`. For XAMPP, you should put the `LibreEHR` folder into `\XAMPP\htdocs\`.
+
+
+
+Navigate to the LibreEHR Setup page by pointing a webbrowser to `localhost/libreEHR/setup.php`.
+
+**Note:**
+1. Make sure that your XAMPP or WAMP control panel has Apache and MySQL turned on
+ 2. Apache needs to be on port 80, 443
+ 3. mySQL needs to be on port 3306
+
+Follow the instructions in [Section 3. Setup](#setup)
+
+## 2B. Linux Installation
 
 ##  Unpacking
 
@@ -146,6 +207,39 @@ The `Initial User's Last Name` is the value to be used as their last name.  This
 
 The `Initial Group` is the first group, basically name of the practice, that will be created.  A user may belong to multiple groups, which again, can be altered on the user administration page. It is suggested that no more than one group per office be used.
 
+Need to put in:
+#### Step 2
+Leave default as the "Site ID:" and press continue.
+
+![First Step](./Documentation/1_Installing/images/windows_installation/Step_1.png)
+
+Make sure that there are no undefined index errors, if so make sure that you changed the php.ini file, or have the correct version of XAMPP.
+
+![Second Step](./Documentation/1_Installing/images/windows_installation/Step_2.png)
+
+Then after the second step, continue and leave the option "Have setup create the database" and press continue.
+
+![Third Step](./Documentation/1_Installing/images/windows_installation/Step_3.png)
+
+For the fourth step, enter a "Password" and "Initial User Password". You are free to change the "Initial User" to your own username, but for convenience you can also leave it as admin. Then press continue.
+
+![Fourth Step](./Documentation/1_Installing/images/windows_installation/Step_4.png)
+
+Then after the fourth step, you can press continue through the others as long as the steps above were followed with clarity, the rest should have no errors, and each remaining page can be continued without change.
+
+![Fifth Step](./Documentation/1_Installing/images/windows_installation/Step_5.png)
+
+![Sixth Step](./Documentation/1_Installing/images/windows_installation/Step_6.png)
+
+![Seventh Step](./Documentation/1_Installing/images/windows_installation/Step_7.png)
+
+![Eigth Step](./Documentation/1_Installing/images/windows_installation/Step_8.png)
+
+![Ninth Step](./Documentation/1_Installing/images/windows_installation/Step_9.png)
+
+![Tenth Step](./Documentation/1_Installing/images/windows_installation/Step_10.png)
+
+**Yay, you have successfull setup LibreEHR!**
 
 #### Step 3
 This is where setup will configure LibreHealthEHR.  It will first create the database and connect to it to create the initial tables.  It will then write the mysql database configuration to the `librehealthehr/sites/default/sqlconf.php` file. 
@@ -282,84 +376,6 @@ librehealthehr/sites/default/letter_templates
 
 If there are other files that you have customized, then you will also need to treat those carefully.
 
-##  Windows Setup
-
-#### Setup
-To run LibreEHR on Windows, [XAMPP](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/5.6.30/) is needed with a compatible version
-
-**Note:** 
-
-1. Must have php [7.0](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/_) or [5.6](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/) ([5.6.30](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/5.6.30/) recommended)
-
-2. php 7.1x is not currently supported
-
-Clone the LibreEHR [repository](https://github.com/LibreHealthIO/LibreEHR) into your console eg. [GitBash](https://git-for-windows.github.io/), [Cmder](http://cmder.net/)
-
-After cloning LibreEHR, the `php.ini` file is located in `xampp\php\` directory.
-
-Open this file with your text editor eg. [Subl](https://www.sublimetext.com/3).
-
-There will be 4 php files located in `xampp\php`. The  one you need is the one with the file type "Configuration Settings". Make the following changes in the php.ini file:
-
-```
-max_execution_time = 600
-max_input_time = 600
-max_input_vars = 3000
-memory_limit = 512M
-post_max_size = 32M
-upload_max_filesize = 32M
-session.gc_maxlifetime = 14400
-short_open_tag = On
-display_errors = Off
-upload_tmp_dir is set to a correct default value that will work on your system
-error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE
-```
-
-**Make sure that strict mode is disabled in Mysql**
-
-**[How to disable Mysql strict mode?](#how-to-disable-mysql-strict-mode-?)**
-
-#### Step 1
-Navigate to LibreEHR Setup:
-localhost/libreEHR/setup.php
-
-**Note:**
-1. Make sure that your XAMPP control panel has Apache and MySQL turned on
-2. Apache needs to be on port 80, 443
-3. mySQL needs to be on port 3306
-
-#### Step 2
-Leave default as the "Site ID:" and press continue.
-
-![First Step](./Documentation/1_Installing/images/windows_installation/Step_1.png)
-
-Make sure that there are no undefined index errors, if so make sure that you changed the php.ini file, or have the correct version of XAMPP.
-
-![Second Step](./Documentation/1_Installing/images/windows_installation/Step_2.png)
-
-Then after the second step, continue and leave the option "Have setup create the database" and press continue.
-
-![Third Step](./Documentation/1_Installing/images/windows_installation/Step_3.png)
-
-For the fourth step, enter a "Password" and "Initial User Password". You are free to change the "Initial User" to your own username, but for convenience you can also leave it as admin. Then press continue.
-
-![Fourth Step](./Documentation/1_Installing/images/windows_installation/Step_4.png)
-
-Then after the fourth step, you can press continue through the others as long as the steps above were followed with clarity, the rest should have no errors, and each remaining page can be continued without change.
-
-![Fifth Step](./Documentation/1_Installing/images/windows_installation/Step_5.png)
-
-![Sixth Step](./Documentation/1_Installing/images/windows_installation/Step_6.png)
-
-![Seventh Step](./Documentation/1_Installing/images/windows_installation/Step_7.png)
-
-![Eigth Step](./Documentation/1_Installing/images/windows_installation/Step_8.png)
-
-![Ninth Step](./Documentation/1_Installing/images/windows_installation/Step_9.png)
-
-![Tenth Step](./Documentation/1_Installing/images/windows_installation/Step_10.png)
-
-**Yay, you have successfull setup LibreEHR!**
 
 ## FAQ
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,11 +3,11 @@ Last Updated: December 26th, 2017
 
 ### Table of Contents
 
-**[1. Overview of Directories](#1.-overview-of-directories)**
+**[1. Overview of Directories](#overview-of-directories)**
 
-**[2A. Windows Installation](#windows-setup)**
+**[2A. Windows Installation](#windows-installation)**
 
-**[2B. Linux Installation](#linix-setup)**
+**[2B. Linux Installation](#linux-installation)**
 
 **[3. Setup](#setup)**
 
@@ -17,6 +17,7 @@ Last Updated: December 26th, 2017
 
 **[6. FAQ](#faq)**
 
+<div id='overview-of-directories'/>
 ##  1. Overview of Directories
 
 NOTE: The most recent documentations can be found on the [LibreHealth](http://librehealth.io/) website.
@@ -35,62 +36,23 @@ sql: Contains initial database images
 
 gacl: Contains embedded php-GACL (access controls)
 
+<div id='windows-installation'/>
 ## 2A. Windows Installation
 
-To run LibreEHR on Windows, [XAMPP](https://www.apachefriends.org/index.html) or [WAMP](http://www.wampserver.com/en/) is needed with a compatible version of php. 
+The following instructions are for Windows systems only. For instructions on installing LibreEHR onto Linux systems, please refer to [Section 2B](#linux-installation)
 
-**Note:** 
+To run LibreEHR on Windows, a compatible version of [XAMPP](https://www.apachefriends.org/index.html) or [WAMP](http://www.wampserver.com/en/) is needed. Compatible versions are 7.0 or 5.6 (5.6.30 is recommended). Versions 7.1x is not currently supported.
 
-1. Must have php [7.0](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/_) or [5.6](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/) ([5.6.30](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/5.6.30/) recommended)
-
-2. php 7.1x is not currently supported
-
-Navigate to your `php.ini` file. You can find the `php.ini` file by looking at the following destination :
-* In case of WAMP :
-`C:\WAMP\BIN\PHP\php.ini` OR (left click )  wampmanager icon -> PHP -> php.ini
-* In case of XAMPP:
-`C:\xampp\php\php.ini.`.
-
-Open this file with your text editor (eg. [Subl](https://www.sublimetext.com/3)).
-
-There will be 4 php files located in `xampp\php` or `\WAMP\BIN\PHP`. The one you need is the one with the file type "Configuration Settings". Make the following changes in the php.ini file:
-
-```
-max_execution_time = 600
-max_input_time = 600
-max_input_vars = 3000
-memory_limit = 512M
-post_max_size = 32M
-upload_max_filesize = 32M
-session.gc_maxlifetime = 14400
-short_open_tag = On
-display_errors = Off
-upload_tmp_dir is set to a correct default value that will work on your system
-error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE
-```
-
-**Make sure that strict mode is disabled in Mysql**
-
-**[How to disable Mysql strict mode?](#how-to-disable-mysql-strict-mode-?)**
-
-Clone the LibreEHR [repository](https://github.com/LibreHealthIO/LibreEHR) into your computer using a console  (eg. [GitBash](https://git-for-windows.github.io/) or [Cmder](http://cmder.net/)).
+Clone the LibreEHR [repository](https://github.com/LibreHealthIO/LibreEHR) into your computer using a console (eg. [GitBash](https://git-for-windows.github.io/) or [Cmder](http://cmder.net/)).
 
 The cloned repository should be moved into the root folder of the webserver you are using. For WAMP, you should put the 'LibreEHR' folder into `\wamp\www\`. For XAMPP, you should put the `LibreEHR` folder into `\XAMPP\htdocs\`.
 
-
-
-Navigate to the LibreEHR Setup page by pointing a webbrowser to `localhost/libreEHR/setup.php`.
-
-**Note:**
-1. Make sure that your XAMPP or WAMP control panel has Apache and MySQL turned on
- 2. Apache needs to be on port 80, 443
- 3. mySQL needs to be on port 3306
-
 Follow the instructions in [Section 3. Setup](#setup)
 
+<div id='linux-installation'/>
 ## 2B. Linux Installation
 
-##  Unpacking
+###  Unpacking
 
 The LibreHealthEHR release archive should be named as follows:
 
@@ -105,13 +67,13 @@ Be sure to use the `-p` flag when using tar, as certain permissions must be pres
 
 LibreHealthEHR will be extracted into a directory named `librehealthehr`.
 
-Alternatively you can download the source code directly from the repository located at [librehealthehr](https://github.com/LibreHealthIO/librehealthehr) using
+Alternatively, you can download the source code directly from the repository located at [librehealthehr](https://github.com/LibreHealthIO/librehealthehr) using
 
 ```
 git clone https://github.com/LibreHealthIO/LibreEHR librehealthehr
 ```
 
-##  Setup
+###  Setup
 
 To run LibreHealthEHR, MariaDB (prefered) or MySQL, and Apache or another PHP-capable webserver must be configured.
 
@@ -128,7 +90,7 @@ If you don't already have it, download and install [Apache](www.apache.org), [Ma
   * Session variables
   * PHP libcurl support (optional for operation, mandatory for billing)
   
-4. If installing on Linux, make sure these dependencies are met:
+4. Make sure these dependencies are met:
 ```
 apache2
 mysql-server (or if using mariadb, then use 'mariadb-server' instead)
@@ -172,6 +134,8 @@ librehealthehr/interface/main/calendar/modules/PostCalendar/pntemplates/cache.
 
 **Note:** In linux, if the webserver user name is `apache`, then the command `chown -R apache:apache directory_name` will grant global write permissions to the directories, and we recommend making these changes permanent. Should the page display errors related to file or directory writing priviledges you may click the 'Check Again' button to try again (after fixing permissions).
 
+<div id='setup'/>
+## 3. Setup
 
 #### Step 1
 You need to tell setup whether it needs to create the database on its own, or if you have already created the database.  MySQL root priveleges will be required to create a database.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ Last Updated: December 26th, 2017
 
 **[6. FAQ](#faq)**
 
-## Overview of Directories
+## 1. Overview of Directories
 <div id='overview-of-directories'/>
 
 NOTE: The most recent documentations can be found on the [LibreHealth](http://librehealth.io/) website.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,8 +17,8 @@ Last Updated: December 26th, 2017
 
 **[6. FAQ](#faq)**
 
+## Overview of Directories
 <div id='overview-of-directories'/>
-##  1. Overview of Directories
 
 NOTE: The most recent documentations can be found on the [LibreHealth](http://librehealth.io/) website.
 
@@ -36,8 +36,8 @@ sql: Contains initial database images
 
 gacl: Contains embedded php-GACL (access controls)
 
-<div id='windows-installation'/>
 ## 2A. Windows Installation
+<div id='windows-installation'/>
 
 The following instructions are for Windows systems only. For instructions on installing LibreEHR onto Linux systems, please refer to [Section 2B](#linux-installation)
 
@@ -47,10 +47,20 @@ Clone the LibreEHR [repository](https://github.com/LibreHealthIO/LibreEHR) into 
 
 The cloned repository should be moved into the root folder of the webserver you are using. For WAMP, you should put the 'LibreEHR' folder into `\wamp\www\`. For XAMPP, you should put the `LibreEHR` folder into `\XAMPP\htdocs\`.
 
+Point your web-browser to the LibreEHR Setup script at localhost/libreEHR/setup.php. 
+
+Leave the "Site ID:" as default and press continue.
+
+![First Step](./Documentation/1_Installing/images/windows_installation/Step_1.png)
+
+Make sure that there are no undefined index errors. If there are any, make sure that you changed the php.ini file and have the correct version of XAMPP or WAMP.
+
+![Second Step](./Documentation/1_Installing/images/windows_installation/Step_2.png)
+
 Follow the instructions in [Section 3. Setup](#setup)
 
-<div id='linux-installation'/>
 ## 2B. Linux Installation
+<div id='linux-installation'/>
 
 ###  Unpacking
 
@@ -122,7 +132,7 @@ The setup script will step you through the configuration of the LibreHealthEHR.
 The first screen of the setup script will ensure that the webserver user (in linux, often is `apache`, `www-data`, or `nobody`) has write privileges on certain files and directories. 
 The files include `librehealthehr/sites/default/sqlconf.php` and `librehealthehr/interface/modules/zend_modules/config/application.config.php`.
 
-In linux, these can be set by `chmod a+w filename` command to grant global write permissions to the file. The directories include: 
+These can be set by `chmod a+w filename` command to grant global write permissions to the file. The directories include: 
 ```
 librehealthehr/gacl/admin/templates_c
 librehealthehr/sites/default/edi
@@ -132,13 +142,17 @@ librehealthehr/interface/main/calendar/modules/PostCalendar/pntemplates/compiled
 librehealthehr/interface/main/calendar/modules/PostCalendar/pntemplates/cache. 
 ```
 
-**Note:** In linux, if the webserver user name is `apache`, then the command `chown -R apache:apache directory_name` will grant global write permissions to the directories, and we recommend making these changes permanent. Should the page display errors related to file or directory writing priviledges you may click the 'Check Again' button to try again (after fixing permissions).
+**Note:** If the webserver user name is `apache`, then the command `chown -R apache:apache directory_name` will grant global write permissions to the directories. We recommend making these changes permanent. Should the page display errors related to file or directory writing priviledges you may click the 'Check Again' button to try again (after fixing permissions).
 
-<div id='setup'/>
 ## 3. Setup
+<div id='setup'/>
+
+The setup.php script will run you through setting up LibreEHR.
 
 #### Step 1
 You need to tell setup whether it needs to create the database on its own, or if you have already created the database.  MySQL root priveleges will be required to create a database.
+
+![Third Step](./Documentation/1_Installing/images/windows_installation/Step_3.png)
 
 #### Step 2
 You will be presented with a number of fields which specify the MySQL server details and the `librehealthehr` directory paths.
@@ -171,51 +185,21 @@ The `Initial User's Last Name` is the value to be used as their last name.  This
 
 The `Initial Group` is the first group, basically name of the practice, that will be created.  A user may belong to multiple groups, which again, can be altered on the user administration page. It is suggested that no more than one group per office be used.
 
-Need to put in:
-#### Step 2
-Leave default as the "Site ID:" and press continue.
-
-![First Step](./Documentation/1_Installing/images/windows_installation/Step_1.png)
-
-Make sure that there are no undefined index errors, if so make sure that you changed the php.ini file, or have the correct version of XAMPP.
-
-![Second Step](./Documentation/1_Installing/images/windows_installation/Step_2.png)
-
-Then after the second step, continue and leave the option "Have setup create the database" and press continue.
-
-![Third Step](./Documentation/1_Installing/images/windows_installation/Step_3.png)
-
-For the fourth step, enter a "Password" and "Initial User Password". You are free to change the "Initial User" to your own username, but for convenience you can also leave it as admin. Then press continue.
-
 ![Fourth Step](./Documentation/1_Installing/images/windows_installation/Step_4.png)
-
-Then after the fourth step, you can press continue through the others as long as the steps above were followed with clarity, the rest should have no errors, and each remaining page can be continued without change.
-
-![Fifth Step](./Documentation/1_Installing/images/windows_installation/Step_5.png)
-
-![Sixth Step](./Documentation/1_Installing/images/windows_installation/Step_6.png)
-
-![Seventh Step](./Documentation/1_Installing/images/windows_installation/Step_7.png)
-
-![Eigth Step](./Documentation/1_Installing/images/windows_installation/Step_8.png)
-
-![Ninth Step](./Documentation/1_Installing/images/windows_installation/Step_9.png)
-
-![Tenth Step](./Documentation/1_Installing/images/windows_installation/Step_10.png)
-
-**Yay, you have successfull setup LibreEHR!**
 
 #### Step 3
 This is where setup will configure LibreHealthEHR.  It will first create the database and connect to it to create the initial tables.  It will then write the mysql database configuration to the `librehealthehr/sites/default/sqlconf.php` file. 
 
 Should anything fail during Step 3, you may have to remove the existing database or tables before you can try again. If no errors occur, you will see a `Continue` button at the bottom.
 
+![Sixth Step](./Documentation/1_Installing/images/windows_installation/Step_6.png)
 
 #### Step 4
 This step will install and configure the embedded phpGACL access controls.  It will first write configuration settings to files.  It will then configure the database.  It will then give the `Initial User` administrator access. 
 
 Should anything fail during Step 4, you may have to remove the existing database or tables before you can try again. If no errors occur, you will see a `Continue` button at the bottom.
 
+![Seventh Step](./Documentation/1_Installing/images/windows_installation/Step_7.png)
 
 #### Step 5
 You will be given instructions on configuring the PHP.  We suggest you print these instructions for future reference.  Instructions are given to edit the `php.ini` configuration file.  If possible, the location of your `php.ini` file will be displayed in green. 
@@ -266,6 +250,8 @@ In order to take full advantage of the patient documents capability you must mak
 
 Restart apache service. Instructions on doing that are given in the FAQ section.
 
+![Eigth Step](./Documentation/1_Installing/images/windows_installation/Step_8.png)
+
 
 #### Step 6
 You will be given instructions on configuring the Apache web server.  We suggest you print these instructions for future reference. Instructions are given to secure the`librehealthehrwebroot/sites/*/documents`, `librehealthehrwebroot/sites/*/edi` and `librehealthehrwebroot/sites/*/era` directories, which contain patient information. This can be done be either placing pertinent `.htaccess` files in these directories or by editing the apache configuration file. 
@@ -310,6 +296,8 @@ General-purpose fax support requires customization within LibreHealthEHR at Admi
 * mogrify from the ImageMagick package
 * tiff2pdf, tiffcp and tiffsplit from the libtiff-tools package
 * enscript
+
+![Ninth Step](./Documentation/1_Installing/images/windows_installation/Step_9.png)
 
 
 ##   Setting Up Access Control

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,13 +47,13 @@ Clone the LibreEHR [repository](https://github.com/LibreHealthIO/LibreEHR) into 
 
 The cloned repository should be moved into the root folder of the webserver you are using. For WAMP, you should put the 'LibreEHR' folder into `\wamp\www\`. For XAMPP, you should put the `LibreEHR` folder into `\XAMPP\htdocs\`.
 
-Point your web-browser to the LibreEHR Setup script at localhost/libreEHR/setup.php. 
+Point your web-browser to the LibreEHR Setup script. Do this by typing `localhost/libreEHR/setup.php` into the URL bar. A setup script will pop up.
 
-Leave the "Site ID:" as default and press continue.
+On the first page, Leave the "Site ID:" as default and press continue.
 
 ![First Step](./Documentation/1_Installing/images/windows_installation/Step_1.png)
 
-Make sure that there are no undefined index errors. If there are any, make sure that you changed the php.ini file and have the correct version of XAMPP or WAMP.
+On the second page, make sure that there are no undefined index errors. If there are any, make sure that you changed the php.ini file and have the correct version of XAMPP or WAMP. Press continue.
 
 ![Second Step](./Documentation/1_Installing/images/windows_installation/Step_2.png)
 
@@ -87,7 +87,7 @@ git clone https://github.com/LibreHealthIO/LibreEHR librehealthehr
 
 To run LibreHealthEHR, MariaDB (prefered) or MySQL, and Apache or another PHP-capable webserver must be configured.
 
-If you don't already have it, download and install [Apache](www.apache.org), [MariaDB](https://mariadb.org) (prefered) or [MySQL](www.mysql.com), and [PHP.](www.php.net)
+If you don't already have it, download and install [Apache](www.apache.org); [MariaDB](https://mariadb.org) (prefered) or [MySQL](www.mysql.com); and [PHP.](www.php.net).
 
 **Note:**
 
@@ -204,9 +204,9 @@ Should anything fail during Step 4, you may have to remove the existing database
 #### Step 5
 You will be given instructions on configuring the PHP.  We suggest you print these instructions for future reference.  Instructions are given to edit the `php.ini` configuration file.  If possible, the location of your `php.ini` file will be displayed in green. 
 
-If your `php.ini` file location is not displayed, then you will need to search for it.  The location of the `php.ini` file is dependent on the operating system.  In linux, `php.ini` is generally found inside the `/etc/php/7.0` directory.  In Windows, the `XAMPP` package places the `php.ini` file in the `xampp\apache\bin\` directory. 
+If your `php.ini` file location is not displayed, then you will need to search for it.  The location of the `php.ini` file is dependent on the operating system.  In linux, `php.ini` is generally found inside the `/etc/php/7.0` directory.  In Windows, the `XAMPP` package places the `php.ini` file in the `xampp\apache\bin\` directory. The `WAMPP` package places the `php.ini` file in the `WAMP\BIN\PHP\` directory.
 
-To ensure proper functioning of LibreHealthEHR you must make sure that settings in the `php.ini` file include:
+To ensure proper functioning of LibreHealthEHR you must make sure that the `php.ini` file includes the following settings:
 ```
 max_execution_time = 600
 max_input_time = 600
@@ -219,44 +219,42 @@ short_open_tag = On
 display_errors = Off
 upload_tmp_dir is set to a correct default value that will work on your system
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE
+file_uploads = On
 ``` 
-Make sure that settings in MYSQL /etc/mysql/my.cnf file include: 
+Make sure that the MYSQL /etc/mysql/my.cnf file include the following settings: 
 ```
 key_buffer_size set to 1024M
 innodb_buffer_pool_size set to 70% of available RAM.
 ```
-Make sure you have disabled strict mode in Mysql . 
+Make sure that you have disabled strict mode in Mysql . 
 
 ## How to disable Mysql strict mode?
 
-Make the following changes in the `my.ini/my.cnf`:
-Find it here `C:\WAMP\BIN\MYSQL\MySQL Server 5.6\my.ini` OR `C:\xampp\mysql\bin\my.ini` 
-OR (left click ) wampmanager icon -> MYSQL -> my.ini
-In Linux it's typically located in /etc/mysql
+Navigate to your my.ini/my.cnf file. You can find the file by looking at the following destinations :
 
-    1.  Look for the following line:
+In case of WAMP : C:\WAMP\BIN\MYSQL\MySQL Server 5.6\my.ini OR (left click ) wampmanager icon -> MYSQL -> my.ini
+In case of XAMPP: C:\xampp\mysql\bin\my.ini In Linux it is typically located in /etc/mysql
+Make the following changes in your my.ini/my.cnf file :
+
+1.  Look for the following line:
     sql-mode = STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
-    or sometimes it maybe sql_mode
+    (sometimes it may be called sql_mode)
 
-    2.  Change it to:
-```
-        sql_mode="" (Blank)
-```
+2.  Change it to:
+    sql-mode="" (Blank)
 
-(XAMPP)
- If you don't find this parameter in the my.ini file, you should run server, open http://localhost/phpmyadmin/, click on the "variables" tab, search for "sql mode", and then set it to:""
+3. Restart the MySQL service.
 
-In order to take full advantage of the patient documents capability you must make sure that settings in `php.ini` file include `file_uploads = On`, that `upload_max_filesize` is appropriate for your use, and that `upload_tmp_dir` is set to a correct value that will work on your system.
-
-Restart apache service. Instructions on doing that are given in the FAQ section.
+4. Restart WAMPP/XAMPP Server.
+(XAMPP) If you cannot find this parameter in the my.ini file, you should run server, open http://localhost/phpmyadmin/, click on the "variables" tab, search for "sql mode", and then set it to: ""
 
 ![Eigth Step](./Documentation/1_Installing/images/windows_installation/Step_8.png)
 
 
 #### Step 6
-You will be given instructions on configuring the Apache web server.  We suggest you print these instructions for future reference. Instructions are given to secure the`librehealthehrwebroot/sites/*/documents`, `librehealthehrwebroot/sites/*/edi` and `librehealthehrwebroot/sites/*/era` directories, which contain patient information. This can be done be either placing pertinent `.htaccess` files in these directories or by editing the apache configuration file. 
+You will be given instructions on configuring the Apache web server.  We suggest you print these instructions for future reference. Instructions are given to secure the`librehealthehrwebroot/sites/*/documents`, `librehealthehrwebroot/sites/*/edi` and `librehealthehrwebroot/sites/*/era` directories, which contains patient information. This can be done by either placing pertinent `.htaccess` files in these directories or by editing the apache configuration file. 
 
-The location of the apache configuration file is dependent on the operating system.  In linux, you can type `httpd -V` or `apache2ctle  -V` on the commandline;  the location to the configuration file will be the `HTTPD_ROOT` variable plus the `SERVER_CONFIG_FILE` variable. In Windows, the` XAMPP` package places the configuration file at `xampp\apache\conf\httpd.conf`. 
+The location of the apache configuration file is dependent on the operating system.  In linux, you can type `httpd -V` or `apache2ctle  -V` on the commandline;  the location to the configuration file will be the `HTTPD_ROOT` variable plus the `SERVER_CONFIG_FILE` variable. In Windows, the` XAMPP` package places the configuration file at `xampp\apache\conf\original\httpd.conf`. 
 
 To secure the `/documents`, `/edi` and `/era` directories you can paste following to the end of the apache configuration file (ensure you put full path to directories):
 ```
@@ -284,7 +282,7 @@ For proper access to all pages of the website, enable the `mod_rewrite` module b
 
 The final screen includes some additional instructions and important information. We suggest you print these instructions for future reference.
 
-Once the system has been configured properly, you may login.  Connect to the webserver where the files are stored with your web browser.  Login to the system using the username that you picked (default is `admin`), and the password.  From there, select the `Administration` option, and customize the system to your needs.  Add users and groups as is needed. For information on using LibreHealthEHR, consult the User Documentation located in the `Documentation` folder, or the documentation at [LibreHealth](http://librehealth.io/).
+Once the system has been configured properly, you may login.  Connect to the webserver where the files are stored with your web browser.  Login to the system using the username that you picked (default is `admin`), and the password.  From there, select the `Administration` option, and customize the system to your needs.  Add users and groups as is needed. For information on using LibreHealthEHR, consult the User Documentation in the `Documentation` folder, or the documentation on the [LibreHealth](http://librehealth.io/) website.
 
 Reading `librehealthehr/sites/default/config.php` is a good idea.
 
@@ -300,23 +298,25 @@ General-purpose fax support requires customization within LibreHealthEHR at Admi
 ![Ninth Step](./Documentation/1_Installing/images/windows_installation/Step_9.png)
 
 
-##   Setting Up Access Control
+## 4. Setting Up Access Control
+<div id='setting-up-access-control'/>
 
 phpGACL access controls are installed and configured automatically during LibreHealthEHR setup.  It can be administered within LibreHealthEHR in the admin->acl menu.  This is very powerful access control software. 
 
-Learn more about phpGACL [here](http://phpgacl.sourceforge.net/). We recommend that you read the phpGACL manual, the `/librehealthehr/Documentation/README.phpgacl.md` file, and the online documentation at [LibreHealth](http://librehealth.io/) . We also reccomend that you read the comments in `/librehealthehr/library/acl.inc`.
+Learn more about phpGACL [here](http://phpgacl.sourceforge.net/). We recommend that you read the phpGACL manual, the `/librehealthehr/Documentation/README.phpgacl.md` file, and the online documentation on the [LibreHealth](http://librehealth.io/) website. We also recommend that you read the comments in `/librehealthehr/library/acl.inc`.
 
-##  Upgrading
+##  5. Upgrading
+<div id='upgrading'/>
 
 Be sure to back up your LibreHealthEHR installation and database before upgrading!
 
-Upgrading LibreHealthEHR is currently done by replacing the old `librehealthehr` directory with a newer version. And, ensure you copy your settings from the following old `librehealthehr` files to the new configuration files (we do not recommend simply copying the entire files):
+Upgrading LibreHealthEHR is currently done by replacing the old `librehealthehr` directory with a newer version. Ensure that you copy your settings from the  old `librehealthehr` files to the new configuration files (we do not recommend simply copying the entire files):
 
 ```
 librehealthehr/sites/default/sqlconf.php
 ```
 
-In this `sqlconf.php` file, set  `$config = 1;` (found near bottom of file within bunch of slashes)
+In this `sqlconf.php` file, set  `$config = 1;` (found near the bottom of the file within a bunch of slashes)
 
 The following directories should be copied from the old version to the new version:
 ```
@@ -328,8 +328,8 @@ librehealthehr/sites/default/letter_templates
 
 If there are other files that you have customized, then you will also need to treat those carefully.
 
-
-## FAQ
+## 6. FAQ
+<div id='faq'/>
 
 **Q. How can I install Apache, MySQL, and PHP on Windows?**
 


### PR DESCRIPTION
changelog:

1. Reorganized document to make more logical sense (I think. Please see if you disagree.), and cut down on redundancy. Principally, the original documents had a lot of overlap between the 'Setup' and 'Windows setup' section. I combined both of them together, and removed any repeated information, in a new section called 'Setup'. 

I also separated the first section into two smaller ones: 'Windows installation', and 'Linux installation'. 
I think this should improve upon the clarity of the document quite a bit. For example, when I first read the original document, I thought I needed to install MariaDB, Apache, PHP, and XAMPP for Windows; in reality, all I needed was XAMPP -- the other three came with it. 

2. Fixed a bunch of typos and grammatical errors.
3. Added mention of WAMP being a possible alternative to XAMPP.
4. Added mention of the user having to move LibreEHR to the root folder (htdocs or www). The original document did not mention this, and I, a user who had never used XAMPP before, had to spend quite a while figuring out how to get it to work.
5. The Apache configuration files for windows is not at xampp\apache\conf\httpd.conf, but xampp\apache\conf\original\httpd.conf